### PR TITLE
Upgrade package to use koa@2 and node@8

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
     "extends": "vgno",
-    "ecmaFeatures": {
-        "generators": true
+    "parserOptions": {
+        "ecmaVersion": 2017
     }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 *.log
 .DS_Store
 coverage
+package-lock.json
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-    - 0.12
-    - 4
-    - 5
+    - 7.6
+    - 8
 after_script:
     - cat coverage/lcov.info | node_modules/.bin/coveralls

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var normalize = require('path').posix.normalize;
+const normalize = require('path').posix.normalize;
 
 module.exports = normalizePath;
 
@@ -15,32 +15,32 @@ function normalizePath(opts) {
         opts.chained = opts.chained || true;
     }
 
-    return function* (next) {
+    return async function(ctx, next) {
         if (opts.defer) {
-            yield next;
+            await next();
         }
 
-        var path;
+        let path;
 
         // We have already done a redirect and we will continue if we are in chained mode
-        if (opts.chained && this.status === 301) {
-            path = getPath(this.response.get('Location'), this.querystring);
-        } else if (this.status !== 301) {
-            path = getPath(this.originalUrl, this.querystring);
+        if (opts.chained && ctx.status === 301) {
+            path = getPath(ctx.response.get('Location'), ctx.querystring);
+        } else if (ctx.status !== 301) {
+            path = getPath(ctx.originalUrl, ctx.querystring);
         }
 
         if (path) {
-            var normalizedPath = normalize(path);
+            const normalizedPath = normalize(path);
             if (path !== normalizedPath) {
-                var query = this.querystring.length ? '?' + this.querystring : '';
+                const query = ctx.querystring.length ? '?' + ctx.querystring : '';
 
-                this.status = 301;
-                this.redirect(normalizedPath + query);
+                ctx.status = 301;
+                ctx.redirect(normalizedPath + query);
             }
         }
 
         if (!opts.defer) {
-            yield next;
+            await next();
         }
     };
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "license": "MIT",
   "devDependencies": {
     "coveralls": "~2.11.6",
-    "eslint": "~1.10.3",
-    "eslint-config-vgno": "~5.0.0",
+    "eslint": "~4.16.0",
+    "eslint-config-vgno": "~7.0.0",
     "expect": "~1.13.4",
     "istanbul": "~0.4.2",
     "mocha": "~2.3.4"


### PR DESCRIPTION
**Summary**
- [x] Upgrades package to use `async/await` required in `koa@2`
- [x] Bumps travis to `node@8`
- [x] Upgrades `eslint` since it was a little ancient and didn't support `async/await`

This is obviously a breaking change and should be released as a `major` bump.